### PR TITLE
A number of updates to get the library and example to compile out of the box on Arduino 1.8.x

### DIFF
--- a/example/example.ino
+++ b/example/example.ino
@@ -39,18 +39,14 @@ void setup() {
 
   // print sensor information
   Serial.println();
-  Serial.print(F("catalog listing:\t"));
-  Serial.println(*rsc.catalog_listing());
-  Serial.print(F("serial number:\t\t"));
-  Serial.println(*rsc.serial_number());
+  rsc.print_catalog_listing();
+  rsc.print_serial_number();
   Serial.print(F("pressure range:\t\t"));
   Serial.println(rsc.pressure_range());
   Serial.print(F("pressure minimum:\t"));
   Serial.println(rsc.pressure_minimum());
-  Serial.print(F("pressure unit:\t\t"));
-  Serial.println(*rsc.pressure_unit_name());
-  Serial.print(F("pressure type:\t\t"));
-  Serial.println(*rsc.pressure_type_name());
+  rsc.print_pressure_unit_name();
+  rsc.print_pressure_type_name();
   Serial.println();
 
   // measure temperature

--- a/example/example.ino
+++ b/example/example.ino
@@ -39,22 +39,22 @@ void setup() {
 
   // print sensor information
   Serial.println();
-  Serial.print("catalog listing:\t");
-  Serial.println(rsc.catalog_listing());
-  Serial.print("serial number:\t\t");
-  Serial.println(rsc.serial_number());
-  Serial.print("pressure range:\t\t");
+  Serial.print(F("catalog listing:\t"));
+  Serial.println(*rsc.catalog_listing());
+  Serial.print(F("serial number:\t\t"));
+  Serial.println(*rsc.serial_number());
+  Serial.print(F("pressure range:\t\t"));
   Serial.println(rsc.pressure_range());
-  Serial.print("pressure minimum:\t");
+  Serial.print(F("pressure minimum:\t"));
   Serial.println(rsc.pressure_minimum());
-  Serial.print("pressure unit:\t\t");
-  Serial.println(rsc.pressure_unit_name());
-  Serial.print("pressure type:\t\t");
-  Serial.println(rsc.pressure_type_name());
+  Serial.print(F("pressure unit:\t\t"));
+  Serial.println(*rsc.pressure_unit_name());
+  Serial.print(F("pressure type:\t\t"));
+  Serial.println(*rsc.pressure_type_name());
   Serial.println();
 
   // measure temperature
-  Serial.print("temperature: ");
+  Serial.print(F("temperature: "));
   Serial.println(rsc.get_temperature());
   Serial.println();
   delay(5);
@@ -62,7 +62,7 @@ void setup() {
 
 void loop() {
   // measure pressure
-  Serial.print("pressure: ");
+  Serial.print(F("pressure: "));
   Serial.println(rsc.get_pressure());
   delay(1000);
 }

--- a/src/Honeywell_RSC.cpp
+++ b/src/Honeywell_RSC.cpp
@@ -121,56 +121,56 @@ void Honeywell_RSC::get_pressure_minimum() {
 }
 
 void Honeywell_RSC::get_pressure_unit() {
-  char buf[RSC_PRESSURE_UNIT_LEN] = {0};
+  unsigned char buf[RSC_PRESSURE_UNIT_LEN] = {0};
   eeprom_read(RSC_PRESSURE_UNIT_MSB, RSC_PRESSURE_UNIT_LEN, buf);
   buf[RSC_PRESSURE_UNIT_LEN - 1] = '\0';
   if (buf[RSC_PRESSURE_UNIT_LEN - 2] == 'O') {
     _pressure_unit = INH2O;
-    _pressure_unit_name = "inH2O";
+    strncpy(_pressure_unit_name, "inH20", name_buff_sizes);
   } else if (buf[RSC_PRESSURE_UNIT_LEN - 2] == 'a') {
     if (buf[RSC_PRESSURE_UNIT_LEN - 4] == 'K') {
       _pressure_unit = KPASCAL;
-      _pressure_unit_name = "kilopascal";
+      strncpy(_pressure_unit_name, "kilopascal", name_buff_sizes);
     } else if (buf[RSC_PRESSURE_UNIT_LEN - 4] == 'M') {
       _pressure_unit = MPASCAL;
-      _pressure_unit_name = "megapascal";
+      strncpy(_pressure_unit_name, "megapascal", name_buff_sizes);
     } else {
       _pressure_unit = PASCAL;
-      _pressure_unit_name = "pascal";
+      strncpy(_pressure_unit_name, "pascal", name_buff_sizes);
     }
   } else if (buf[RSC_PRESSURE_UNIT_LEN - 2] == 'r') {
     if (buf[RSC_PRESSURE_UNIT_LEN - 5] == 'm') {
       _pressure_unit = mBAR;
-      _pressure_unit_name = "millibar";
+      strncpy(_pressure_unit_name, "millibar", name_buff_sizes);
     } else {
       _pressure_unit = BAR;
-      _pressure_unit_name = "bar";
+      strncpy(_pressure_unit_name, "bar", name_buff_sizes);
     }
   } else if (buf[RSC_PRESSURE_UNIT_LEN - 2] == 'i') {
     _pressure_unit = PSI;
-    _pressure_unit_name = "psi";
+    strncpy(_pressure_unit_name, "psi", name_buff_sizes);
   }
 }
 
 void Honeywell_RSC::get_pressure_type() {
-  char buf[RSC_SENSOR_TYPE_LEN];
+  unsigned char buf[RSC_SENSOR_TYPE_LEN];
   eeprom_read(RSC_PRESSURE_REFERENCE, RSC_SENSOR_TYPE_LEN, buf);
   switch (buf[0]) {
     case 'D':
       _pressure_type = DIFFERENTIAL;
-      _pressure_type_name = "differential";
+      strncpy(_pressure_type_name, "differential", name_buff_sizes);
       break;
     case 'A':
       _pressure_type = ABSOLUTE;
-      _pressure_type_name = "absolute";
+      strncpy(_pressure_type_name, "absolute", name_buff_sizes);
       break;
     case 'G':
       _pressure_type = GAUGE;
-      _pressure_type_name = "gauge";
+      strncpy(_pressure_type_name, "gauge", name_buff_sizes);
       break;
     default:
       _pressure_type = DIFFERENTIAL;
-      _pressure_type_name = "differential";
+      strncpy(_pressure_type_name, "differential", name_buff_sizes);
   }
 }
 
@@ -406,16 +406,16 @@ void Honeywell_RSC::set_mode(RSC_MODE mode) {
   switch (mode) {
     case NORMAL_MODE:
       if (_data_rate < N_DR_20_SPS || _data_rate > N_DR_1000_SPS) {
-        Serial.println("RSC: Normal mode not supported with the current selection of data rate\n");
-        Serial.println("RSC: You will see erronous readings\n");
+        Serial.println(F("RSC: Normal mode not supported with the current selection of data rate\n"));
+        Serial.println(F("RSC: You will see erronous readings\n"));
         l_mode = NA_MODE;
       } else
         l_mode = NORMAL_MODE;
       break;
     case FAST_MODE:
       if (_data_rate < F_DR_40_SPS || _data_rate > F_DR_2000_SPS) {
-        Serial.println("RSC: Fast mode not supported with the current selection of data rate\n");
-        Serial.println("RSC: You will see erronous readings\n");
+        Serial.println(F("RSC: Fast mode not supported with the current selection of data rate\n"));
+        Serial.println(F("RSC: You will see erronous readings\n"));
         l_mode = NA_MODE;
       } else
         l_mode = FAST_MODE;

--- a/src/Honeywell_RSC.cpp
+++ b/src/Honeywell_RSC.cpp
@@ -124,6 +124,16 @@ void Honeywell_RSC::get_pressure_unit() {
   unsigned char buf[RSC_PRESSURE_UNIT_LEN] = {0};
   eeprom_read(RSC_PRESSURE_UNIT_MSB, RSC_PRESSURE_UNIT_LEN, buf);
   buf[RSC_PRESSURE_UNIT_LEN - 1] = '\0';
+
+  Serial.print(F("content of buf from eeprom_read of pressure unit: | "));
+  for (size_t i=0; i<RSC_PRESSURE_UNIT_LEN; i++){
+    Serial.print(buf[i], HEX);
+    Serial.print(F("="));
+    Serial.print(buf[i]);
+    Serial.print(F(" | "))
+  }
+  Serial.println(F(""));
+
   if (buf[RSC_PRESSURE_UNIT_LEN - 2] == 'O') {
     _pressure_unit = INH2O;
     strncpy(_pressure_unit_name, "inH20", name_buff_sizes);

--- a/src/Honeywell_RSC.cpp
+++ b/src/Honeywell_RSC.cpp
@@ -126,31 +126,31 @@ void Honeywell_RSC::get_pressure_unit() {
   buf[RSC_PRESSURE_UNIT_LEN - 1] = '\0';
 
   Serial.println(F("DBG: content of buf from eeprom_read of pressure unit: "));
-  print_array_from_memory(&(buf[0]), RSC_PRESSURE_UNIT_LEN);
+  print_array_from_memory((char const * const)&(buf[0]), RSC_PRESSURE_UNIT_LEN);
 
-  if (buf[RSC_PRESSURE_UNIT_LEN - 2] == 'O') {
+  if ((char)buf[RSC_PRESSURE_UNIT_LEN - 2] == 'O') {
     _pressure_unit = INH2O;
     strncpy(_pressure_unit_name, "inH20", name_buff_sizes);
-  } else if (buf[RSC_PRESSURE_UNIT_LEN - 2] == 'a') {
-    if (buf[RSC_PRESSURE_UNIT_LEN - 4] == 'K') {
+  } else if ((char)buf[RSC_PRESSURE_UNIT_LEN - 2] == 'a') {
+    if ((char)buf[RSC_PRESSURE_UNIT_LEN - 4] == 'K') {
       _pressure_unit = KPASCAL;
       strncpy(_pressure_unit_name, "kilopascal", name_buff_sizes);
-    } else if (buf[RSC_PRESSURE_UNIT_LEN - 4] == 'M') {
+    } else if ((char)buf[RSC_PRESSURE_UNIT_LEN - 4] == 'M') {
       _pressure_unit = MPASCAL;
       strncpy(_pressure_unit_name, "megapascal", name_buff_sizes);
     } else {
       _pressure_unit = PASCAL;
       strncpy(_pressure_unit_name, "pascal", name_buff_sizes);
     }
-  } else if (buf[RSC_PRESSURE_UNIT_LEN - 2] == 'r') {
-    if (buf[RSC_PRESSURE_UNIT_LEN - 5] == 'm') {
+  } else if ((char)buf[RSC_PRESSURE_UNIT_LEN - 2] == 'r') {
+    if ((char)buf[RSC_PRESSURE_UNIT_LEN - 5] == 'm') {
       _pressure_unit = mBAR;
       strncpy(_pressure_unit_name, "millibar", name_buff_sizes);
     } else {
       _pressure_unit = BAR;
       strncpy(_pressure_unit_name, "bar", name_buff_sizes);
     }
-  } else if (buf[RSC_PRESSURE_UNIT_LEN - 2] == 'i') {
+  } else if ((char)buf[RSC_PRESSURE_UNIT_LEN - 2] == 'i') {
     _pressure_unit = PSI;
     strncpy(_pressure_unit_name, "psi", name_buff_sizes);
   }
@@ -164,7 +164,7 @@ void Honeywell_RSC::get_pressure_type() {
   eeprom_read(RSC_PRESSURE_REFERENCE, RSC_SENSOR_TYPE_LEN, buf);
 
   Serial.println(F("DBG: content of buf from eeprom_read of sensor type: "));
-  print_array_from_memory(&(buf[0]), RSC_SENSOR_TYPE_LEN);
+  print_array_from_memory((char const * const)&(buf[0]), RSC_SENSOR_TYPE_LEN);
 
   switch (buf[0]) {
     case 'D':
@@ -445,6 +445,38 @@ void Honeywell_RSC::setup_adc(uint8_t* adc_init_values) {
   uint8_t command[5] = {RSC_ADC_RESET_COMMAND, adc_init_values[0], adc_init_values[1], adc_init_values[2], adc_init_values[3]};
   adc_write(0, 5, command);
   delay(5);
+}
+
+void Honeywell_RSC::print_catalog_listing(void){
+  Serial.print(F("catalog_listing: "));
+  for (size_t i=0; i<RSC_SENSOR_NAME_LEN; i++){
+    Serial.print((char)(_catalog_listing[i]));
+  }
+  Serial.println();
+}
+
+void Honeywell_RSC::print_serial_number(void){
+  Serial.print(F("serial_number: "));
+  for (size_t i=0; i<RSC_SENSOR_NUMBER_LEN; i++){
+    Serial.print((char)(_serial_number[i]));
+  }
+  Serial.println();
+}
+
+void Honeywell_RSC::print_pressure_unit_name(void){
+  Serial.print(F("pressure_unit: "));
+  for (size_t i=0; i<name_buff_sizes; i++){
+    Serial.print((char)(_pressure_unit_name[i]));
+  }
+  Serial.println();
+}
+
+void Honeywell_RSC::print_pressure_type_name(void){
+  Serial.print(F("pressure_type_name: "));
+  for (size_t i=0; i<name_buff_sizes; i++){
+    Serial.print((char)(_pressure_type_name[i]));
+  }
+  Serial.println();
 }
 
 

--- a/src/Honeywell_RSC.cpp
+++ b/src/Honeywell_RSC.cpp
@@ -125,14 +125,8 @@ void Honeywell_RSC::get_pressure_unit() {
   eeprom_read(RSC_PRESSURE_UNIT_MSB, RSC_PRESSURE_UNIT_LEN, buf);
   buf[RSC_PRESSURE_UNIT_LEN - 1] = '\0';
 
-  Serial.print(F("content of buf from eeprom_read of pressure unit: | "));
-  for (size_t i=0; i<RSC_PRESSURE_UNIT_LEN; i++){
-    Serial.print(buf[i], HEX);
-    Serial.print(F("="));
-    Serial.print(buf[i]);
-    Serial.print(F(" | "))
-  }
-  Serial.println(F(""));
+  Serial.println(F("DBG: content of buf from eeprom_read of pressure unit: "));
+  print_array_from_memory(&(buf[0]), RSC_PRESSURE_UNIT_LEN);
 
   if (buf[RSC_PRESSURE_UNIT_LEN - 2] == 'O') {
     _pressure_unit = INH2O;
@@ -160,11 +154,18 @@ void Honeywell_RSC::get_pressure_unit() {
     _pressure_unit = PSI;
     strncpy(_pressure_unit_name, "psi", name_buff_sizes);
   }
+
+  Serial.println(F("DBG: content of _pressure_unit_name: "));
+  print_array_from_memory(&(_pressure_unit_name[0]), name_buff_sizes);
 }
 
 void Honeywell_RSC::get_pressure_type() {
   unsigned char buf[RSC_SENSOR_TYPE_LEN];
   eeprom_read(RSC_PRESSURE_REFERENCE, RSC_SENSOR_TYPE_LEN, buf);
+
+  Serial.println(F("DBG: content of buf from eeprom_read of sensor type: "));
+  print_array_from_memory(&(buf[0]), RSC_SENSOR_TYPE_LEN);
+
   switch (buf[0]) {
     case 'D':
       _pressure_type = DIFFERENTIAL;
@@ -182,6 +183,9 @@ void Honeywell_RSC::get_pressure_type() {
       _pressure_type = DIFFERENTIAL;
       strncpy(_pressure_type_name, "differential", name_buff_sizes);
   }
+
+  Serial.println(F("DBG: content of _pressure_type_name: "));
+  print_array_from_memory(&(_pressure_type_name[0]), name_buff_sizes);
 }
 
 void Honeywell_RSC::get_coefficients() {
@@ -441,5 +445,16 @@ void Honeywell_RSC::setup_adc(uint8_t* adc_init_values) {
   uint8_t command[5] = {RSC_ADC_RESET_COMMAND, adc_init_values[0], adc_init_values[1], adc_init_values[2], adc_init_values[3]};
   adc_write(0, 5, command);
   delay(5);
+}
+
+void print_array_from_memory(unsigned char const * const start, size_t length){
+  Serial.print(F("DBG "));
+  for (size_t i=0; i<length; i++){
+    Serial.print(*(start+i), HEX);
+    Serial.print(F("="));
+    Serial.print(*(start+i));
+    Serial.print(F(" | "))
+  }
+  Serial.println(F(""));
 }
 

--- a/src/Honeywell_RSC.cpp
+++ b/src/Honeywell_RSC.cpp
@@ -447,14 +447,4 @@ void Honeywell_RSC::setup_adc(uint8_t* adc_init_values) {
   delay(5);
 }
 
-void print_array_from_memory(char const * const start, size_t length){
-  Serial.print(F("DBG "));
-  for (size_t i=0; i<length; i++){
-    Serial.print(*(start+i), HEX);
-    Serial.print(F("="));
-    Serial.print(*(start+i));
-    Serial.print(F(" | "));
-  }
-  Serial.println(F(""));
-}
 

--- a/src/Honeywell_RSC.cpp
+++ b/src/Honeywell_RSC.cpp
@@ -447,13 +447,13 @@ void Honeywell_RSC::setup_adc(uint8_t* adc_init_values) {
   delay(5);
 }
 
-void print_array_from_memory(unsigned char const * const start, size_t length){
+void print_array_from_memory(char const * const start, size_t length){
   Serial.print(F("DBG "));
   for (size_t i=0; i<length; i++){
     Serial.print(*(start+i), HEX);
     Serial.print(F("="));
     Serial.print(*(start+i));
-    Serial.print(F(" | "))
+    Serial.print(F(" | "));
   }
   Serial.println(F(""));
 }

--- a/src/Honeywell_RSC.cpp
+++ b/src/Honeywell_RSC.cpp
@@ -128,7 +128,13 @@ void Honeywell_RSC::get_pressure_unit() {
   Serial.println(F("DBG: content of buf from eeprom_read of pressure unit: "));
   print_array_from_memory((char const * const)&(buf[0]), RSC_PRESSURE_UNIT_LEN);
 
-  if ((char)buf[RSC_PRESSURE_UNIT_LEN - 2] == 'O') {
+  // option 1: just copy
+  for (size_t i=0; i<RSC_PRESSURE_UNIT_LEN; i++){
+    _pressure_unit_name[i] = (char)buf[i];
+  }
+
+  // option 2: try to match; I think the logics here are at least in part broken
+  if ((char)buf[3] == '2') {
     _pressure_unit = INH2O;
     strncpy(_pressure_unit_name, "inH20", name_buff_sizes);
   } else if ((char)buf[RSC_PRESSURE_UNIT_LEN - 2] == 'a') {

--- a/src/Honeywell_RSC.h
+++ b/src/Honeywell_RSC.h
@@ -46,14 +46,16 @@ public:
   void set_mode(RSC_MODE mode);
   
   // getter functions
-  char* catalog_listing() const {return _catalog_listing;}
-  char* serial_number() const {return _serial_number;}
+  const unsigned char* catalog_listing() const {return &_catalog_listing[0];}
+  const unsigned char* serial_number() const {return &_serial_number[0];}
   float pressure_range() const {return _pressure_range;}
   float pressure_minimum() const {return _pressure_minimum;}
-  char* pressure_unit_name() const {return _pressure_unit_name;}
-  char* pressure_type_name() const {return _pressure_type_name;}
+  const char* pressure_unit_name() const {return &_pressure_unit_name[0];}
+  const char* pressure_type_name() const {return &_pressure_type_name[0];}
 
 private:
+  static constexpr size_t name_buff_sizes = 32;
+
   // physical pin connections
   uint8_t _drdy_pin;
   uint8_t _cs_ee_pin;
@@ -61,13 +63,13 @@ private:
 
   // from EEPROM
   unsigned char _catalog_listing[RSC_SENSOR_NAME_LEN];
-  char _serial_number[RSC_SENSOR_NUMBER_LEN];
+  unsigned char _serial_number[RSC_SENSOR_NUMBER_LEN];
   float _pressure_range;
   float _pressure_minimum;
   PRESSURE_U _pressure_unit;
-  char* _pressure_unit_name;
+  char _pressure_unit_name[name_buff_sizes];
   PRESSURE_T _pressure_type;
-  char* _pressure_type_name;
+  char _pressure_type_name[name_buff_sizes];
 
   // ADC
   RSC_DATA_RATE _data_rate;

--- a/src/Honeywell_RSC.h
+++ b/src/Honeywell_RSC.h
@@ -80,6 +80,16 @@ private:
   int32_t _t_raw;
 };
 
-void print_array_from_memory(unsigned char const * const start, size_t length);
+template<typename T>
+void print_array_from_memory(T const * const start, size_t length){
+  Serial.print(F("DBG "));
+  for (size_t i=0; i<length; i++){
+    Serial.print(*(start+i), HEX);
+    Serial.print(F("="));
+    Serial.print(*(start+i));
+    Serial.print(F(" | "));
+  }
+  Serial.println(F(""));
+}
 
 #endif // HONEYWELL_RSC_H

--- a/src/Honeywell_RSC.h
+++ b/src/Honeywell_RSC.h
@@ -52,6 +52,10 @@ public:
   float pressure_minimum() const {return _pressure_minimum;}
   const char* pressure_unit_name() const {return &_pressure_unit_name[0];}
   const char* pressure_type_name() const {return &_pressure_type_name[0];}
+  void print_catalog_listing(void);
+  void print_serial_number(void);
+  void print_pressure_unit_name(void);
+  void print_pressure_type_name(void);
 
 private:
   static constexpr size_t name_buff_sizes = 32;
@@ -84,6 +88,7 @@ template<typename T>
 void print_array_from_memory(T const * const start, size_t length){
   Serial.print(F("DBG "));
   for (size_t i=0; i<length; i++){
+    Serial.print(F("0x"));
     Serial.print(*(start+i), HEX);
     Serial.print(F("="));
     Serial.print(*(start+i));

--- a/src/Honeywell_RSC.h
+++ b/src/Honeywell_RSC.h
@@ -80,4 +80,6 @@ private:
   int32_t _t_raw;
 };
 
+void print_array_from_memory(unsigned char const * const start, size_t length);
+
 #endif // HONEYWELL_RSC_H


### PR DESCRIPTION
This follows the problems met in issue #3 .

Changelog:

- use ```F("")``` style macros in serial prints to put data in flash rather than ram
- fix some ```unsigned char``` vs ```char``` signature and typing issues that were creating compile errors
- fix some c-string issues; copy using ```strncopy``` rather than just assign values on the stack for output strings...

The code on this pull request should compile fine (if not let me know; "it works on my machine"). I do not have the sensors home so cannot test if this works; @jvoermans keep me posted :) .