### PR TITLE
Fix ADC setup error & temp conversion. Add parms to init

### DIFF
--- a/src/Honeywell_RSC.h
+++ b/src/Honeywell_RSC.h
@@ -10,7 +10,7 @@ class Honeywell_RSC {
 public:
   Honeywell_RSC(int drdy_pin, int cs_ee_pin, int cs_adc_pin);
 
-  void init();
+  void init(RSC_DATA_RATE dr = N_DR_20_SPS, RSC_MODE mode = NORMAL_MODE);
 
   // chip selection
   void select_eeprom();
@@ -38,6 +38,7 @@ public:
   void adc_write(uint8_t reg, uint8_t num_bytes, uint8_t *data);
 
   // other ADC related functions
+  void reset_adc();
   void setup_adc(uint8_t* adc_init_values);
   void add_dr_delay();
   


### PR DESCRIPTION
- Output sensor values are completely wrong because ADC is not correctly initialised with setup values from EEPROM. This is because ADC setup tries to write ADC reset command and registers in a single 5 byte write. This change separates the reset and the write of the 4 setup values. 
- Updated Temp conversion to Celcius so it handles signed values.
- Added optional parameters to the init function.